### PR TITLE
Automated Changelog Entry for 0.3.3 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,35 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.3
+
+([Full Changelog](https://github.com/jtpio/jupyterlab-cell-flash/compare/0.3.2...f54f7918f87a3e7bd50d10ef8c75c053cac88b70))
+
+### Maintenance and upkeep improvements
+
+- Update to Jupyter Packaging 0.10, adopt the releaser [#17](https://github.com/jtpio/jupyterlab-cell-flash/pull/17) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Bump tar from 6.1.4 to 6.1.11 [#16](https://github.com/jtpio/jupyterlab-cell-flash/pull/16) ([@dependabot](https://github.com/dependabot))
+- Bump path-parse from 1.0.6 to 1.0.7 [#15](https://github.com/jtpio/jupyterlab-cell-flash/pull/15) ([@dependabot](https://github.com/dependabot))
+- Bump tar from 6.1.0 to 6.1.4 [#14](https://github.com/jtpio/jupyterlab-cell-flash/pull/14) ([@dependabot](https://github.com/dependabot))
+- Bump postcss from 7.0.35 to 7.0.36 [#13](https://github.com/jtpio/jupyterlab-cell-flash/pull/13) ([@dependabot](https://github.com/dependabot))
+- Bump normalize-url from 4.5.0 to 4.5.1 [#12](https://github.com/jtpio/jupyterlab-cell-flash/pull/12) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.4.4 to 7.4.6 [#11](https://github.com/jtpio/jupyterlab-cell-flash/pull/11) ([@dependabot](https://github.com/dependabot))
+- Bump browserslist from 4.16.3 to 4.16.6 [#10](https://github.com/jtpio/jupyterlab-cell-flash/pull/10) ([@dependabot](https://github.com/dependabot))
+- Bump hosted-git-info from 2.8.8 to 2.8.9 [#9](https://github.com/jtpio/jupyterlab-cell-flash/pull/9) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-cell-flash/graphs/contributors?from=2021-03-11&to=2021-09-14&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-cell-flash+involves%3Adependabot+updated%3A2021-03-11..2021-09-14&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-cell-flash+involves%3Ajtpio+updated%3A2021-03-11..2021-09-14&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.2
 
 ### Changes
 
 - Update to the latest JupyterLab 3.0 packages: https://github.com/jtpio/jupyterlab-cell-flash/pull/8
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.3.3 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jtpio/jupyterlab-cell-flash  |
| Branch  | main  |
| Version Spec | 0.3.3 |
| Since | 0.3.2 |